### PR TITLE
Add CLI command to propose changing the owners or threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ version = "0.0.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
+ "borsh",
  "clap 3.0.0-beta.2",
  "multisig",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ anchor-client = "0.4.4"
 anchor-lang = "0.4.4"
 clap = "3.0.0-beta.2"
 multisig = { path = "../programs/multisig" }
+borsh = "0.8.2"
 
 [[bin]]
 path = "src/main.rs"

--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -88,6 +88,19 @@ pub mod multisig {
         Ok(())
     }
 
+    // Set owners and threshold at once.
+    pub fn set_owners_and_change_threshold<'info>(
+        ctx: Context<'_, '_, '_, 'info, Auth<'info>>,
+        owners: Vec<Pubkey>,
+        threshold: u64,
+    ) -> Result<()> {
+        set_owners(
+            Context::new(ctx.program_id, ctx.accounts, ctx.remaining_accounts),
+            owners,
+        )?;
+        change_threshold(ctx, threshold)
+    }
+
     // Sets the owners field on the multisig. The only way this can be invoked
     // is via a recursive call from execute_transaction -> set_owners.
     pub fn set_owners(ctx: Context<Auth>, owners: Vec<Pubkey>) -> Result<()> {


### PR DESCRIPTION
Currently the CLI can propose one transaction: upgrading a program. This pull request extends it with a second transaction type: altering the multisig itself.

This cherry-picks https://github.com/project-serum/multisig/pull/5 to be able to change the threshold and owners at the same time. Both are required for the CLI, if you don't want to change either one, then you should just pass in the current value.

I haven’t tested this yet, because it is very tedious to go through the sequence of commands every time. I am first going to add an `--output json` mode to the program, and that should make it possible to write some integration tests that call all the commands in sequence.