### PR TITLE
Add --output-json mode to the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,8 @@ dependencies = [
  "borsh",
  "clap 3.0.0-beta.2",
  "multisig",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,8 @@ anchor-lang = "0.4.4"
 clap = "3.0.0-beta.2"
 multisig = { path = "../programs/multisig" }
 borsh = "0.8.2"
+serde = "1.0"
+serde_json = "1.0"
 
 [[bin]]
 path = "src/main.rs"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::PathBuf;
 
 use anchor_client::solana_sdk::bpf_loader_upgradeable;
@@ -192,15 +193,21 @@ fn main() {
     let client = Client::new_with_options(opts.cluster, payer, CommitmentConfig::confirmed());
     let program = client.program(opts.multisig_program_id);
 
-    match opts.subcommand {
-        SubCommand::CreateMultisig(cmd_opts) => create_multisig(program, cmd_opts),
-        SubCommand::ShowMultisig(cmd_opts) => show_multisig(program, cmd_opts),
-        SubCommand::ShowTransaction(cmd_opts) => show_transaction(program, cmd_opts),
-        SubCommand::ProposeUpgrade(cmd_opts) => propose_upgrade(program, cmd_opts),
-        SubCommand::ProposeChangeMultisig(cmd_opts) => propose_change_multisig(program, cmd_opts),
-        SubCommand::Approve(cmd_opts) => approve(program, cmd_opts),
-        SubCommand::ExecuteTransaction(cmd_opts) => execute_transaction(program, cmd_opts),
-    }
+    let result: Box<dyn fmt::Display> = match opts.subcommand {
+        SubCommand::CreateMultisig(cmd_opts) => Box::new(create_multisig(program, cmd_opts)),
+        SubCommand::ShowMultisig(cmd_opts) => Box::new(show_multisig(program, cmd_opts)),
+        SubCommand::ShowTransaction(cmd_opts) => Box::new(show_transaction(program, cmd_opts)),
+        SubCommand::ProposeUpgrade(cmd_opts) => Box::new(propose_upgrade(program, cmd_opts)),
+        SubCommand::ProposeChangeMultisig(cmd_opts) => {
+            Box::new(propose_change_multisig(program, cmd_opts))
+        }
+        SubCommand::Approve(cmd_opts) => Box::new(approve(program, cmd_opts)),
+        SubCommand::ExecuteTransaction(cmd_opts) => {
+            Box::new(execute_transaction(program, cmd_opts))
+        }
+    };
+
+    println!("{}", result);
 }
 
 fn get_multisig_program_address(program: &Program, multisig_pubkey: &Pubkey) -> (Pubkey, u8) {
@@ -208,7 +215,25 @@ fn get_multisig_program_address(program: &Program, multisig_pubkey: &Pubkey) -> 
     Pubkey::find_program_address(&seeds, &program.id())
 }
 
-fn create_multisig(program: Program, opts: CreateMultisigOpts) {
+struct CreateMultisigResult {
+    multisig_address: Pubkey,
+    multisig_program_derived_address: Pubkey,
+}
+
+impl fmt::Display for CreateMultisigResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Multisig address:        {}", self.multisig_address)?;
+        writeln!(
+            f,
+            "Program derived address: {}",
+            self.multisig_program_derived_address
+        )?;
+        writeln!(f, "The multisig can sign on behalf of the derived address.")?;
+        Ok(())
+    }
+}
+
+fn create_multisig(program: Program, opts: CreateMultisigOpts) -> CreateMultisigResult {
     // Enforce a few basic sanity checks.
     opts.validate_or_exit();
 
@@ -221,20 +246,14 @@ fn create_multisig(program: Program, opts: CreateMultisigOpts) {
     // up forever.
     let multisig_account = Keypair::new();
 
-    println!("Multisig account: {}", multisig_account.pubkey());
-
     // The Multisig program will sign transactions on behalf of a derived
-    // account. Print this derived account, so it can be used to set as e.g.
+    // account. Return this derived account, so it can be used to set as e.g.
     // the upgrade authority for a program. Because not every derived address is
     // valid, a bump seed is appended to the seeds. It is stored in the `nonce`
     // field in the multisig account, and the Multisig program includes it when
     // deriving its program address.
     let (program_derived_address, nonce) =
         get_multisig_program_address(&program, &multisig_account.pubkey());
-    println!(
-        "Program derived address (use as upgrade authority): {}",
-        program_derived_address,
-    );
 
     program
         .request()
@@ -267,34 +286,182 @@ fn create_multisig(program: Program, opts: CreateMultisigOpts) {
         })
         .send()
         .expect("Failed to send transaction.");
+
+    CreateMultisigResult {
+        multisig_address: multisig_account.pubkey(),
+        multisig_program_derived_address: program_derived_address,
+    }
 }
 
-fn show_multisig(program: Program, opts: ShowMultisigOpts) {
+struct ShowMultisigResult {
+    multisig_program_derived_address: Pubkey,
+    threshold: u64,
+    owners: Vec<Pubkey>,
+}
+
+impl fmt::Display for ShowMultisigResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "Program derived address: {}",
+            self.multisig_program_derived_address
+        )?;
+        writeln!(
+            f,
+            "Threshold: {} out of {}",
+            self.threshold,
+            self.owners.len()
+        )?;
+        writeln!(f, "Owners:")?;
+        for owner_pubkey in &self.owners {
+            writeln!(f, "  {}", owner_pubkey)?;
+        }
+        Ok(())
+    }
+}
+
+fn show_multisig(program: Program, opts: ShowMultisigOpts) -> ShowMultisigResult {
     let multisig: multisig::Multisig = program
         .account(opts.multisig_address)
         .expect("Failed to read multisig state from account.");
 
     let (program_derived_address, _nonce) =
         get_multisig_program_address(&program, &opts.multisig_address);
-    println!("Program derived address: {}", program_derived_address);
-    println!(
-        "Threshold: {} out of {}",
-        multisig.threshold,
-        multisig.owners.len()
-    );
-    println!("Owners:");
-    for owner_pubkey in &multisig.owners {
-        println!("  {}", owner_pubkey);
+
+    ShowMultisigResult {
+        multisig_program_derived_address: program_derived_address,
+        threshold: multisig.threshold,
+        owners: multisig.owners,
     }
 }
 
-fn show_transaction(program: Program, opts: ShowTransactionOpts) {
+enum ShowTransactionSigners {
+    /// The current owners of the multisig are the same as in the transaction,
+    /// and these are the owners and whether they signed.
+    Current { signers: Vec<(Pubkey, bool)> },
+
+    /// The owners of the multisig have changed since this transaction, so we
+    /// cannot know who the signers were any more, only how many signatures it
+    /// had.
+    Outdated {
+        num_signed: usize,
+        num_owners: usize,
+    },
+}
+
+/// If an `Instruction` is a known one, this contains its details.
+enum ParsedInstruction {
+    BpfLoaderUpgrade {
+        program_to_upgrade: Pubkey,
+        program_data_address: Pubkey,
+        buffer_address: Pubkey,
+        spill_address: Pubkey,
+    },
+    MultisigChange {
+        threshold: u64,
+        owners: Vec<Pubkey>,
+    },
+    Unrecognized,
+}
+
+struct ShowTransactionResult {
+    multisig_address: Pubkey,
+    did_execute: bool,
+    signers: ShowTransactionSigners,
+    instruction: Instruction,
+    parsed_instruction: ParsedInstruction,
+}
+
+impl fmt::Display for ShowTransactionResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Multisig: {}", self.multisig_address)?;
+        writeln!(f, "Did execute: {}", self.did_execute)?;
+
+        match &self.signers {
+            ShowTransactionSigners::Current { signers } => {
+                writeln!(f, "\nSigners:")?;
+                for (owner_pubkey, did_sign) in signers {
+                    writeln!(
+                        f,
+                        "  [{}] {}",
+                        if *did_sign { 'x' } else { ' ' },
+                        owner_pubkey
+                    )?;
+                }
+            }
+            ShowTransactionSigners::Outdated {
+                num_signed,
+                num_owners,
+            } => {
+                writeln!(
+                    f,
+                    "\nThe owners of the multisig have changed since this transaction was created,"
+                )?;
+                writeln!(f, "therefore we cannot show the identities of the signers.")?;
+                writeln!(
+                    f,
+                    "The transaction had {} out of {} signatures.",
+                    num_signed, num_owners,
+                )?;
+            }
+        }
+
+        writeln!(f, "\nInstruction:")?;
+        writeln!(f, "  Program to call: {}", self.instruction.program_id)?;
+        writeln!(f, "  Accounts:\n")?;
+        for account in &self.instruction.accounts {
+            writeln!(
+                f,
+                "    * {}\n      signer: {}, writable: {}\n",
+                account.pubkey, account.is_signer, account.is_writable,
+            )?;
+        }
+
+        match &self.parsed_instruction {
+            ParsedInstruction::BpfLoaderUpgrade {
+                program_to_upgrade,
+                program_data_address,
+                buffer_address,
+                spill_address,
+            } => {
+                writeln!(
+                    f,
+                    "  This is a bpf_loader_upgradeable::upgrade instruction."
+                )?;
+                writeln!(f, "    Program to upgrade:      {}", program_to_upgrade)?;
+                writeln!(f, "    Program data address:    {}", program_data_address)?;
+                writeln!(f, "    Buffer with new program: {}", buffer_address)?;
+                writeln!(f, "    Spill address:           {}", spill_address)?;
+            }
+            ParsedInstruction::MultisigChange { threshold, owners } => {
+                writeln!(
+                    f,
+                    "  This is a multisig::set_owners_and_change_threshold instruction."
+                )?;
+                writeln!(
+                    f,
+                    "    New threshold: {} out of {}",
+                    threshold,
+                    owners.len()
+                )?;
+                writeln!(f, "    New owners:")?;
+                for owner_pubkey in owners {
+                    writeln!(f, "      {}", owner_pubkey)?;
+                }
+            }
+            ParsedInstruction::Unrecognized => {
+                writeln!(f, "  Unrecognized instruction.")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn show_transaction(program: Program, opts: ShowTransactionOpts) -> ShowTransactionResult {
     let transaction: multisig::Transaction = program
         .account(opts.transaction_address)
         .expect("Failed to read transaction data from account.");
-
-    println!("Multisig: {}", transaction.multisig);
-    println!("Did execute: {}", transaction.did_execute);
 
     // Also query the multisig, to get the owner public keys, so we can display
     // exactly who voted.
@@ -306,48 +473,42 @@ fn show_transaction(program: Program, opts: ShowTransactionOpts) {
         .account(transaction.multisig)
         .expect("Failed to read multisig state from account.");
 
-    if transaction.owner_set_seqno == multisig.owner_set_seqno {
-        println!("\nSigners:");
-        for (owner_pubkey, &did_sign) in multisig.owners.iter().zip(&transaction.signers) {
-            println!("  [{}] {}", if did_sign { 'x' } else { ' ' }, owner_pubkey);
+    let signers = if transaction.owner_set_seqno == multisig.owner_set_seqno {
+        // If the owners did not change, match up every vote with its owner.
+        ShowTransactionSigners::Current {
+            signers: multisig
+                .owners
+                .iter()
+                .cloned()
+                .zip(transaction.signers.iter().cloned())
+                .collect(),
         }
     } else {
-        println!("The owners of the multisig have changed since this transaction was created,");
-        println!("therefore we cannot show the identities of the signers.");
-        let num_signatures = transaction
-            .signers
-            .iter()
-            .filter(|&did_sign| *did_sign)
-            .count();
-        println!(
-            "It had {} out of {} signatures.",
-            num_signatures,
-            transaction.signers.len()
-        );
-    }
+        // If the owners did change, we no longer know who voted. The best we
+        // can do is report how many signatures there were.
+        ShowTransactionSigners::Outdated {
+            num_signed: transaction
+                .signers
+                .iter()
+                .filter(|&did_sign| *did_sign)
+                .count(),
+            num_owners: transaction.signers.len(),
+        }
+    };
 
     let instr = Instruction::from(&transaction);
 
-    println!("\nInstruction:");
-    println!("  Program to call: {}", instr.program_id);
-    println!("  Accounts:\n");
-    for account in &instr.accounts {
-        println!(
-            "    * {}\n      signer: {}, writable: {}\n",
-            account.pubkey, account.is_signer, account.is_writable,
-        );
-    }
-
-    if instr.program_id == bpf_loader_upgradeable::ID
+    let parsed_instr = if instr.program_id == bpf_loader_upgradeable::ID
         && bpf_loader_upgradeable::is_upgrade_instruction(&instr.data[..])
     {
         // Account meaning, according to
         // https://docs.rs/solana-sdk/1.5.19/solana_sdk/loader_upgradeable_instruction/enum.UpgradeableLoaderInstruction.html#variant.Upgrade
-        println!("  This is a bpf_loader_upgradeable::upgrade instruction.");
-        println!("    Program to upgrade:      {}", instr.accounts[1].pubkey);
-        println!("    Program data address:    {}", instr.accounts[0].pubkey);
-        println!("    Buffer with new program: {}", instr.accounts[2].pubkey);
-        println!("    Spill address:           {}", instr.accounts[3].pubkey);
+        ParsedInstruction::BpfLoaderUpgrade {
+            program_data_address: instr.accounts[0].pubkey,
+            program_to_upgrade: instr.accounts[1].pubkey,
+            buffer_address: instr.accounts[2].pubkey,
+            spill_address: instr.accounts[3].pubkey,
+        }
     } else
     // Try to deserialize the known multisig instructions. The instruction
     // data starts with an 8-byte tag derived from the name of the function,
@@ -363,26 +524,42 @@ fn show_transaction(program: Program, opts: ShowTransactionOpts) {
         if let Ok(instr) =
             multisig_instruction::SetOwnersAndChangeThreshold::try_from_slice(&instr.data[8..])
         {
-            println!("  This is a multisig::set_owners_and_change_threshold instruction.");
-            println!(
-                "    New threshold: {} out of {}",
-                instr.threshold,
-                instr.owners.len()
-            );
-            println!("    New owners:");
-            for owner_pubkey in &instr.owners {
-                println!("      {}", owner_pubkey);
+            ParsedInstruction::MultisigChange {
+                threshold: instr.threshold,
+                owners: instr.owners,
             }
         } else {
-            println!("  Unrecognized instruction.");
+            ParsedInstruction::Unrecognized
         }
     } else {
-        println!("  Unrecognized instruction.");
+        ParsedInstruction::Unrecognized
+    };
+
+    ShowTransactionResult {
+        multisig_address: transaction.multisig,
+        did_execute: transaction.did_execute,
+        signers: signers,
+        instruction: instr,
+        parsed_instruction: parsed_instr,
+    }
+}
+
+struct ProposeInstructionResult {
+    transaction_address: Pubkey,
+}
+
+impl fmt::Display for ProposeInstructionResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Transaction address: {}", self.transaction_address)
     }
 }
 
 /// Propose the given instruction to be approved and executed by the multisig.
-fn propose_instruction(program: Program, multisig_address: Pubkey, instruction: Instruction) {
+fn propose_instruction(
+    program: Program,
+    multisig_address: Pubkey,
+    instruction: Instruction,
+) -> ProposeInstructionResult {
     // The Multisig program expects `multisig::TransactionAccount` instead of
     // `solana_sdk::AccountMeta`. The types are structurally identical,
     // but not nominally, so we need to convert these.
@@ -392,14 +569,11 @@ fn propose_instruction(program: Program, multisig_address: Pubkey, instruction: 
         .map(multisig::TransactionAccount::from)
         .collect();
 
-    println!("Proposed TX data: {:?}", instruction.data);
-
     // The transaction is stored by the Multisig program in yet another account,
     // that we create just for this transaction. We don't save the private key
     // because the account will be owned by the multisig program later; its
     // funds will be locked forever.
     let transaction_account = Keypair::new();
-    println!("Transaction account: {}", transaction_account.pubkey());
 
     program
         .request()
@@ -438,9 +612,13 @@ fn propose_instruction(program: Program, multisig_address: Pubkey, instruction: 
         })
         .send()
         .expect("Failed to send transaction.");
+
+    ProposeInstructionResult {
+        transaction_address: transaction_account.pubkey(),
+    }
 }
 
-fn propose_upgrade(program: Program, opts: ProposeUpgradeOpts) {
+fn propose_upgrade(program: Program, opts: ProposeUpgradeOpts) -> ProposeInstructionResult {
     let (program_derived_address, _nonce) =
         get_multisig_program_address(&program, &opts.multisig_address);
 
@@ -452,10 +630,13 @@ fn propose_upgrade(program: Program, opts: ProposeUpgradeOpts) {
         &opts.spill_address,
     );
 
-    propose_instruction(program, opts.multisig_address, upgrade_instruction);
+    propose_instruction(program, opts.multisig_address, upgrade_instruction)
 }
 
-fn propose_change_multisig(program: Program, opts: ProposeChangeMultisigOpts) {
+fn propose_change_multisig(
+    program: Program,
+    opts: ProposeChangeMultisigOpts,
+) -> ProposeInstructionResult {
     // Check that the new settings make sense. This check is shared between a
     // new multisig or altering an existing one.
     CreateMultisigOpts::from(&opts).validate_or_exit();
@@ -479,10 +660,18 @@ fn propose_change_multisig(program: Program, opts: ProposeChangeMultisigOpts) {
         accounts: change_addrs.to_account_metas(override_is_signer),
     };
 
-    propose_instruction(program, opts.multisig_address, change_instruction);
+    propose_instruction(program, opts.multisig_address, change_instruction)
 }
 
-fn approve(program: Program, opts: ApproveOpts) {
+struct EmptyResult;
+
+impl fmt::Display for EmptyResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Operation successful.")
+    }
+}
+
+fn approve(program: Program, opts: ApproveOpts) -> EmptyResult {
     program
         .request()
         .accounts(multisig_accounts::Approve {
@@ -496,6 +685,8 @@ fn approve(program: Program, opts: ApproveOpts) {
         .args(multisig_instruction::Approve)
         .send()
         .expect("Failed to send transaction.");
+
+    EmptyResult
 }
 
 /// Wrapper type needed to implement `ToAccountMetas`.
@@ -538,7 +729,7 @@ impl anchor_lang::ToAccountMetas for TransactionAccounts {
     }
 }
 
-fn execute_transaction(program: Program, opts: ExecuteTransactionOpts) {
+fn execute_transaction(program: Program, opts: ExecuteTransactionOpts) -> EmptyResult {
     let (program_derived_address, _nonce) =
         get_multisig_program_address(&program, &opts.multisig_address);
 
@@ -564,4 +755,6 @@ fn execute_transaction(program: Program, opts: ExecuteTransactionOpts) {
         .args(multisig_instruction::ExecuteTransaction)
         .send()
         .expect("Failed to send transaction.");
+
+    EmptyResult
 }


### PR DESCRIPTION
## Overview

This adds an `--output-json` mode to the `multisig` program, which will make it output json to stdout, instead of human-readable text. My use case for this, is writing an integration test that goes through the entire flow of creating a multisig to upgrade a program. The addresses generated by `multisig` are needed as inputs in the next steps, so we need a way to pass the data from the program to the test, and outputting json is a convenient way to do that.

Adding tests is not yet part of this pull request, I will do that in a follow-up.

## Details

* Replace direct `println!` in the program with structs that implement `Display`.
* Also derive `Serialize` for these structs so `serde_json` can serialize them as json.
* Unfortunately `solana_sdk::Pubkey` has a `Serialize` implementation that serializes to json as a list of numbers, which would defeat the purpose of adding json output, because the program expects base58 addresses as input for the next steps. So add a wrapper type `PubkeyBase58` that serializes as a base58 string instead.